### PR TITLE
update Dockerfile to support pack 0.3.0+ releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ FROM bstick12/ubuntu-dind
 
 ARG pack_version
 
-RUN apt-get install wget jq -y
-RUN wget -c https://github.com/buildpack/pack/releases/download/v$pack_version/pack-$pack_version-linux.tar.gz -O - | tar -zx -C /usr/local/bin
+RUN apt-get update && \
+    apt-get install wget jq -y && \
+    rm -rf /var/lib/apt/lists/*
+RUN wget -c https://github.com/buildpack/pack/releases/download/v$pack_version/pack-v$pack_version-linux.tgz -O - | tar -zx -C /usr/local/bin
 
 COPY --from=builder /assets/ /opt/resource
 COPY out /opt/resource/out


### PR DESCRIPTION
Relates to #2 

```yaml
resource_types:
- name: pack-image-resource
  type: docker-image
  privileged: true
  source:
    repository: drnic/pack-concourse-resource
    version: latest
```

Verification of pack:

```
$ docker run -ti --entrypoint "" drnic/pack-concourse-resource pack version
v0.3.0 (git sha: 3123e32ea7c570527c6e2cdb31f4e5c002334287)
```

Testing example.yml:

```
fly -t ohio-drnic sp -c example.yml -p pack-concourse-resource-example -v git-url=https://github.com/buildpack/sample-java-app -v docker-hub-username=drnic -v docker-hub-password=... -v repository=drnic/pack-concourse-resource-sample-app -v pack-builder=cloudfoundry/cnb:cflinuxfs3
```

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/108/63813049-b531bf80-c96f-11e9-89b3-1b6d720afd31.png">
