### PR TITLE
rebuild image if upstream builder changes, contains new buildpacks

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -4,6 +4,11 @@ resources:
   type: git
   source:
     uri: ((git-url))
+- name: ((pack-builder-image)):((pack-builder-tag))
+  type: docker-image
+  source:
+    repository: ((pack-builder-image))
+    version: ((pack-builder-tag))
 - name: pack-goflake
   type: pack-image-resource
   source:
@@ -24,7 +29,10 @@ jobs:
   plan:
   - get: git-resource
     trigger: true
+  - get: ((pack-builder-image)):((pack-builder-tag))
+    trigger: true
+    params: {skip_download: true}
   - put: pack-goflake
     params:
       build: git-resource
-      builder: ((pack-builder))
+      builder: ((pack-builder-image)):((pack-builder-tag))


### PR DESCRIPTION
Suggestion for `example.yml` to show how an app could be automatically rebuilt if the upstream builder image is updated; which means the app gets rebuilt automatically with new buildpacks.

```
fly -t target set-pipeline -c example.yml -p pack-concourse-resource-example \
  -v git-url=https://github.com/buildpack/sample-java-app \
  -v repository=drnic/pack-concourse-resource-sample-app \
  -v pack-builder-image=cloudfoundry/cnb -v pack-builder-tag=cflinuxfs3 ...
```

<img width="1411" alt="image" src="https://user-images.githubusercontent.com/108/63813994-bca69800-c972-11e9-9159-e765d699019e.png">

