### PR TITLE
env_vars is no longer relative to build directory

### DIFF
--- a/out
+++ b/out
@@ -84,7 +84,7 @@ fi
 pack_args=""
 
 if [ ! -z $env_file ]; then
-  pack_args="$pack_args --env-file $build/$env_file"
+  pack_args="$pack_args --env-file $env_file"
 fi
 
 pack build $repository:$tag_name $pack_args --path $build


### PR DESCRIPTION
## Why is this change needed?

For java apps, the build option (which is translated to the --path flag) now needs to point directly to a jar/war instead of to a directory. This means the env_vars can no longer be specified relative to the build directory.

## What else do I need to know

This is a behavioral change to the resource, so it could impact some users. Open to other suggestions if this feels like too big of a break.
